### PR TITLE
Keep README navigation repository-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@ Learn machine learning from the ground up - using Python and a handful of fundam
 
 This repository contains a range of resources associated with the 2nd edition of the university textbook Machine Learning Refined. [Our pedagogical approach](#our-pedagogy) stresses intuition, visualization, and "getting your hands dirty" building real machine learning models from scratch. The only [technical prerequisites](#technical-prerequisites) is a basic understanding of Python and matrix maths.
 
-### Start with the official companion site
+### Choose a repository resource
 
-Visit [mlrefined.com](https://www.mlrefined.com/) for the official guide to the book, chapters, and resource collection. If you want an explanation before opening a raw notebook, use the [visual, step-by-step Python guides](https://www.mlrefined.com/learn):
+Everything needed to study or teach from the book is organized directly in this repository:
 
-- [Gradient descent from scratch in Python](https://www.mlrefined.com/learn/gradient-descent-from-scratch)
-- [Logistic regression from scratch in Python](https://www.mlrefined.com/learn/logistic-regression-from-scratch)
-- [K-means clustering from scratch in Python](https://www.mlrefined.com/learn/k-means-clustering-from-scratch)
+- [Read or download the chapter PDFs](chapter_pdfs)
+- [Run the source Jupyter notebooks](notes)
+- [Practice with the exercises](exercises)
+- [Use the lecture slides](presentations)
 
-For source material, go directly to the [chapter PDFs](https://github.com/neonwatty/machine-learning-refined/tree/main/chapter_pdfs), [Jupyter notebooks](https://github.com/neonwatty/machine-learning-refined/tree/main/notes), [exercises](https://github.com/neonwatty/machine-learning-refined/tree/main/exercises), or [lecture slides](https://github.com/neonwatty/machine-learning-refined/tree/main/presentations).
+For a suggested path through these materials, jump to [Independent learners](#independent-learners) or [Instructors](#instructors).
 
 ## Independent learners
 


### PR DESCRIPTION
## What changed

- replaces the prominent “Start with the official companion site” section with a repository-native resource map
- points arriving GitHub users directly to chapter PDFs, source notebooks, exercises, lecture slides, and the existing learner/instructor workflows
- removes the three top-level guide CTAs that sent users back out of the repository
- retains the official companion-site URL only in the bibliographic “Book and citation” section

## Why

The previous opening pathway was circular: a reader who had already reached the canonical resource repository was immediately encouraged to leave it. The README should instead help that reader discover and use the materials already present here.

## Validation

- diff is limited to `README.md`
- all six links in the replacement panel are repository-relative paths or README anchors
- `chapter_pdfs`, `notes`, `exercises`, and `presentations` exist on `main`
- all 156 canonical Colab URLs are unchanged
- chapter, notebook, exercise, and presentation path occurrence counts are unchanged
- GitHub's Markdown API renders the replacement heading and all links
- `git diff --check` passes
